### PR TITLE
feat: initial i18n support for cheat information strings in remote web panel

### DIFF
--- a/web-panel/bridge/bridge-modules/normalizers.cjs
+++ b/web-panel/bridge/bridge-modules/normalizers.cjs
@@ -412,6 +412,7 @@ function normalizeSnapshot(rawSnapshot) {
     const trainerMeta = {
         session: {
             instanceId: safeString(rawSnapshot.instanceId, 'wand-session'),
+            accessToken: safeString(rawSnapshot.accessToken),
         },
         trainer: {
             trainerId,

--- a/web-panel/bridge/bridge-modules/wand-runtime.cjs
+++ b/web-panel/bridge/bridge-modules/wand-runtime.cjs
@@ -78,7 +78,20 @@ function installIpcHandlers(electron, runtime, boundRenderers, pendingCommandRes
 
     globalThis.__wandRemoteBridgeIpcInstalled = true;
     electron.ipcMain.handle(IPC_CHANNEL.TRAINER_SNAPSHOT, (_event, snapshot) => {
-        runtime.sync(snapshot);
+        try {
+            const allWindows = electron.BrowserWindow.getAllWindows();
+            const win = allWindows[0];
+            win.webContents
+                .executeJavaScript(
+                    `JSON.parse(localStorage.getItem("infinity:globalStore") || "{}")?.token?.accessToken`
+                )
+                .then((accessToken) => {
+                    snapshot.accessToken = accessToken;
+                    runtime.sync(snapshot);
+                });
+        } catch (e) {
+            runtime.sync(snapshot);
+        }
         return true;
     });
     electron.ipcMain.handle(REMOTE_INSTALLED_APPS_CHANNEL, (_event, snapshot) => {

--- a/web-panel/src/features/remote-panel/message-handler.ts
+++ b/web-panel/src/features/remote-panel/message-handler.ts
@@ -4,13 +4,14 @@ import type { PanelAction } from './state';
 
 type Dispatch = (action: PanelAction) => void;
 
-export function handleProtocolMessage(dispatch: Dispatch, message: IncomingMessage, trainerMeta: TrainerMetaPayload | null): void {
+export async function handleProtocolMessage(dispatch: Dispatch, message: IncomingMessage, trainerMeta: TrainerMetaPayload | null): Promise<void> {
     switch (message.type) {
         case 'hello_ack':
             handleHelloAck(dispatch, message.payload.accepted, message.payload.remoteUrl);
             return;
         case 'trainer_meta':
-            dispatch({ type: 'trainerMeta', payload: message.payload });
+            const payloadWithI18n = await fetchI18nForTrainerMeta(message.payload);
+            dispatch({ type: 'trainerMeta', payload: payloadWithI18n });
             return;
         case 'game_status':
             dispatch({ type: 'gameStatus', payload: message.payload });
@@ -58,4 +59,52 @@ function handleValueChanged(dispatch: Dispatch, message: Extract<IncomingMessage
     const cheat = trainerMeta?.schema.cheats.find((item) => item.target === message.payload.target || item.uuid === message.payload.cheatId);
     const nextValue = cheat ? normalizeIncomingValue(cheat, message.payload.value) : message.payload.value;
     dispatch({ type: 'valueChanged', target: message.payload.target, value: nextValue });
+}
+
+async function fetchI18nForTrainerMeta(payload: TrainerMetaPayload): Promise<TrainerMetaPayload> {
+    try {
+        const accessToken = payload?.session?.accessToken;
+        const gameId = payload?.trainer?.gameId;
+        const gameVersion = payload?.trainer?.gameVersion;
+        const language = payload?.trainer?.language;
+
+        const params = new URLSearchParams();
+
+        if (gameVersion) params.append('gameVersions', gameVersion);
+        if (language) params.append('locale', language);
+
+        const url = `https://api.wemod.com/v3/games/${gameId}/trainer?${params.toString()}`;
+        const response = await fetch(url, {
+            method: 'GET',
+            headers: {
+                Authorization: `Bearer ${accessToken}`,
+            },
+        });
+        const trainer = await response.json();
+
+        payload.schema.cheats.forEach((item) => {
+            // name
+            const name = item.name;
+            if (name) {
+                const i18nString = trainer?.i18n?.strings?.[name];
+                if (i18nString) item.name = i18nString;
+            }
+            // description
+            const description = item.description;
+            if (description) {
+                const i18nString = trainer?.i18n?.strings?.[description];
+                if (i18nString) item.description = i18nString;
+            }
+            // instructions
+            const instructions = item.instructions;
+            if (instructions) {
+                const i18nString = trainer?.i18n?.strings?.[instructions];
+                if (i18nString) item.instructions = i18nString;
+            }
+        });
+
+        return payload;
+    } catch (e) {
+        return payload;
+    }
 }

--- a/web-panel/src/features/remote-panel/protocol.ts
+++ b/web-panel/src/features/remote-panel/protocol.ts
@@ -109,6 +109,7 @@ export interface TrainerSummary {
 export interface TrainerMetaPayload {
     session: {
         instanceId: string;
+        accessToken: string;
     };
     trainer: TrainerSummary;
     schema: {


### PR DESCRIPTION
Fetch i18n text by calling Wand’s API and replace it.

I’m still a beginner in frontend development, so the implementation is quite rough. Feel free to modify it into whatever style you prefer.

<img width="2481" height="1294" alt="image" src="https://github.com/user-attachments/assets/a58e7b89-d783-48ee-b8f6-c507c5da1abe" />
