### PR TITLE
fix(asar): path traversal (zip-slip) on extract + Pickle buffer overrun

### DIFF
--- a/AsarSharp/AsarExtractor.cs
+++ b/AsarSharp/AsarExtractor.cs
@@ -41,9 +41,12 @@ namespace AsarSharp
                         var destFilename = Path.Combine(dest, filename);
                         var file = filesystem.GetFile(filename, followLinks);
 
-                        // Path-traversal guard.
-                        string relativePath = Extensions.GetRelativePath(dest, destFilename);
-                        if (relativePath.StartsWith(".."))
+                        // Path-traversal (zip-slip) guard. Uses the normalising
+                        // containment check: GetRelativePath's fast path strips the
+                        // prefix literally without resolving "..", so a crafted entry
+                        // such as "a/../../evil" would otherwise pass this check and be
+                        // written outside "dest".
+                        if (!Extensions.IsPathInside(dest, destFilename))
                         {
                             throw new InvalidOperationException(
                                 $"{fullPath}: file \"{destFilename}\" writes out of the package");
@@ -164,7 +167,7 @@ namespace AsarSharp
 
             var linkTo = Path.Combine(relativeLinkPath, Path.GetFileName(file.Link));
 
-            if (Extensions.GetRelativePath(dest, linkSrcPath).StartsWith(".."))
+            if (!Extensions.IsPathInside(dest, linkSrcPath))
             {
                 throw new InvalidOperationException(
                     $"{fullPath}: file \"{file.Link}\" links out of the package to \"{linkSrcPath}\"");

--- a/AsarSharp/PickleTools/Pickle.cs
+++ b/AsarSharp/PickleTools/Pickle.cs
@@ -231,8 +231,14 @@ namespace AsarSharp.PickleTools
         private void Resize(int newCapacity)
         {
             newCapacity = AlignInt(newCapacity, PAYLOAD_UNIT);
-            byte[] newHeader = new byte[_header.Length + newCapacity];
-            Buffer.BlockCopy(_header, 0, newHeader, 0, _header.Length);
+            // The backing array must hold the header plus the full advertised
+            // payload capacity (matches Chromium's realloc(header_size_ + new_capacity)).
+            // Sizing it from _header.Length under-allocates by _headerSize on the
+            // first growth (when _header is still empty), leaving the payload region
+            // _headerSize bytes short of _capacityAfterHeader and overrunning the
+            // buffer when a write fills the payload.
+            byte[] newHeader = new byte[_headerSize + newCapacity];
+            Buffer.BlockCopy(_header, 0, newHeader, 0, Math.Min(_header.Length, newHeader.Length));
             _header = newHeader;
             _capacityAfterHeader = newCapacity;
         }

--- a/AsarSharp/Utils/Extensions.cs
+++ b/AsarSharp/Utils/Extensions.cs
@@ -97,6 +97,27 @@ namespace AsarSharp.Utils
 
         private static bool IsSeparator(char c) => c == '/' || c == '\\';
 
+        /// <summary>
+        /// Security check for archive extraction: returns true only when
+        /// <paramref name="candidate"/> resolves to a location inside
+        /// <paramref name="root"/>. Both paths are fully normalised first, so
+        /// embedded ".." segments cannot escape the root (zip-slip). The
+        /// <see cref="GetRelativePath"/> fast path must not be used here because
+        /// it strips the prefix literally without resolving "..".
+        /// </summary>
+        public static bool IsPathInside(string root, string candidate)
+        {
+            string fullRoot = TrimTrailingSeparators(Path.GetFullPath(root));
+            string fullCandidate = TrimTrailingSeparators(Path.GetFullPath(candidate));
+
+            if (string.Equals(fullRoot, fullCandidate, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            return fullCandidate.Length > fullRoot.Length
+                   && fullCandidate.StartsWith(fullRoot, StringComparison.OrdinalIgnoreCase)
+                   && IsSeparator(fullCandidate[fullRoot.Length]);
+        }
+
         public static string GetDirectoryName(string path)
         {
             if (string.IsNullOrEmpty(path))


### PR DESCRIPTION
## Summary

Fixes two code-level bugs in the `AsarSharp` pack/extract pipeline found by source audit (full write-ups and reproductions in #142).

> Split note: the `WandEnhancer.TryKillProcess` fix that was originally part of this PR has been moved to its own PR so each change can be reviewed independently.

### 1. `AsarSharp/AsarExtractor.cs` — path traversal / zip-slip (major)
The extraction guard used `Extensions.GetRelativePath`, whose fast path strips the `dest` prefix without resolving `..`, so a crafted entry like `a/../../evil` bypassed the check and was written outside `dest`. The out-of-package symlink guard shared the weakness.
- Added `Extensions.IsPathInside`, which normalises both paths with `Path.GetFullPath` before the containment check.
- Used it for both the file/directory and symlink guards.

### 2. `AsarSharp/PickleTools/Pickle.cs` — payload buffer overrun (major)
`Resize` allocated `_header.Length + newCapacity` but advertised `_capacityAfterHeader = newCapacity`, leaving the backing array `_headerSize` (4) bytes short on the first growth. A serialised asar header of 4089–4092 bytes overran the buffer (`ArgumentException`) during packing.
- Now allocates `_headerSize + newCapacity`, matching Chromium's `Pickle::Resize`.

## Changes
- `AsarSharp/Utils/Extensions.cs` — new `IsPathInside` helper (normalising containment check).
- `AsarSharp/AsarExtractor.cs` — both traversal guards use `IsPathInside`.
- `AsarSharp/PickleTools/Pickle.cs` — corrected `Resize` allocation.

All changes are minimal and localised; no public API or behaviour change beyond the fixes.

## Testing
There is no automated test project for the C# solution and I don't have the WeMod runtime, so I verified by:
- Static reasoning against each code path.
- A standalone arithmetic/string simulation of the Pickle buffer sizing and the path-normalisation guard (results in #142). The current code overruns for header sizes 4089–4092 and lets `a/../../evil` escape; the patched logic handles both while leaving every other size and all legitimate paths unchanged.

Per `CONTRIBUTING.md`, please build the solution in your environment to confirm compilation. Happy to adjust naming/placement (e.g. the `IsPathInside` helper) to fit project conventions.

Fixes #142
