### PR TITLE
fix: correct TryKillProcess retry loop condition

### DIFF
--- a/WandEnhancer/Utils/Common.cs
+++ b/WandEnhancer/Utils/Common.cs
@@ -11,7 +11,12 @@ namespace WandEnhancer.Utils
         public static void TryKillProcess(string processName)
         {
             Process[] processes = Process.GetProcessesByName(processName);
-            for (int i = 0; processes.Length > i || i < 5; i++)
+            // Retry while any target process is still alive, capped at 5 attempts.
+            // The previous condition (processes.Length > i || i < 5) compared the
+            // process count to the loop index and, because of the "|| i < 5", always
+            // ran at least 5 iterations — sleeping ~1.25s even when the process was
+            // never running.
+            for (int i = 0; processes.Length > 0 && i < 5; i++)
             {
                 foreach (var process in processes)
                 {


### PR DESCRIPTION
## Summary

Fixes the `TryKillProcess` retry-loop condition in `WandEnhancer/Utils/Common.cs` (see #144).

```csharp
for (int i = 0; processes.Length > i || i < 5; i++)   // before
for (int i = 0; processes.Length > 0 && i < 5; i++)    // after
```

The previous condition compared the process **count** to the loop **index**, and the `|| i < 5` forced at least 5 iterations of `Thread.Sleep(250)` regardless of state — so `TryKillProcess` stalled ~1.25s before every patch/restore even when WeMod was not running. The new condition retries only while a target process is still alive, capped at 5 attempts.

## Changes
- `WandEnhancer/Utils/Common.cs` — corrected retry-loop condition (one line + explanatory comment).

## Testing
No automated test project exists for the C# solution and I don't have the WeMod runtime; verified by static reasoning about the loop. The change is a one-line condition fix with no API or behaviour change beyond avoiding the needless spin. Please build the solution to confirm compilation per `CONTRIBUTING.md`.

Fixes #144
