### PR TITLE
fix(i18n): stop leaking a ResourceDictionary on every language switch

### DIFF
--- a/WandEnhancer/Core/Services/LocalizationManager.cs
+++ b/WandEnhancer/Core/Services/LocalizationManager.cs
@@ -29,6 +29,11 @@ namespace WandEnhancer.Core.Services
         private static CultureInfo _currentLanguage;
         private static ResourceDictionary _englishBaseDictionary;
 
+        // The locale dictionary currently merged into the application resources. It is built in
+        // code and therefore has no Source, so it cannot be found again by the Source-based lookup
+        // below; tracking it here is what allows the previous one to be removed on every switch.
+        private static ResourceDictionary _currentLocaleDictionary;
+
         public static CultureInfo CurrentLanguage
         {
             get => _currentLanguage;
@@ -104,20 +109,27 @@ namespace WandEnhancer.Core.Services
                 localeDict[entry.Key] = targetDict[entry.Key];
             }
 
-            // Find and replace the old locale dictionary
-            var oldDict = Application.Current.Resources.MergedDictionaries
+            // Find and replace the old locale dictionary. The tracked instance is checked first
+            // because only the very first replacement targets the Source-bearing dictionary merged
+            // by App.xaml; every later one targets a code-built dictionary with no Source.
+            var oldDict = _currentLocaleDictionary ?? Application.Current.Resources.MergedDictionaries
                 .FirstOrDefault(d => d.Source != null && d.Source.OriginalString.StartsWith("Locale/lang."));
 
-            if (oldDict != null)
+            var index = oldDict != null
+                ? Application.Current.Resources.MergedDictionaries.IndexOf(oldDict)
+                : -1;
+
+            if (index >= 0)
             {
-                var index = Application.Current.Resources.MergedDictionaries.IndexOf(oldDict);
-                Application.Current.Resources.MergedDictionaries.Remove(oldDict);
+                Application.Current.Resources.MergedDictionaries.RemoveAt(index);
                 Application.Current.Resources.MergedDictionaries.Insert(index, localeDict);
             }
             else
             {
                 Application.Current.Resources.MergedDictionaries.Add(localeDict);
             }
+
+            _currentLocaleDictionary = localeDict;
             
             if (saveSettings)
             {


### PR DESCRIPTION
﻿Fixes #164

### Problem

`LocalizationManager.SetLanguage` replaces the merged locale `ResourceDictionary` correctly **once**, then appends on every subsequent switch without removing the previous one.

The replacement dictionary is built with `new ResourceDictionary()` and has no `Source` (`:85`), but the lookup for the dictionary to replace requires `d.Source != null` (`:108-109`). The first switch matches App.xaml's `Locale/lang.en-US.xaml`; after that the installed dictionary has no `Source`, the lookup returns `null`, and control reaches the `else` branch that calls `.Add(...)`.

Switching language N times leaves N parsed locale dictionaries merged for the process lifetime. Text stays correct — the last merged dictionary wins — so the symptom is an unbounded memory leak, not wrong strings.

### Change

Track the installed dictionary in `_currentLocaleDictionary` and prefer it when locating the one to replace, keeping the existing `Source`-based predicate as the fallback for the first call.

The index is now resolved before use and the `else` branch is taken when it is `-1`, so a tracked dictionary that is no longer merged appends instead of throwing on `Insert(-1, ...)`. Behaviour is otherwise unchanged: same position in `MergedDictionaries`, same English-base-plus-overlay construction, same settings save.

One file changed, `+17 / -5`.

### Verification

- Control-flow analysis against `master` @ `643c8f8`.
- Compile-checked by dispatching this repo's own `.github/workflows/build.yml` (full `build.ps1` → MSBuild, `windows-latest`) on my fork — I have no local Visual Studio/MSBuild environment. Run linked in a comment below.

Two limits I want to be explicit about rather than imply otherwise:

- The repo has no C# test project, and WPF `MergedDictionaries` behaviour needs a running `Application`, so there is no unit test accompanying this.
- CONTRIBUTING.md asks for manual testing against the current WeMod build; I do not have a licensed WeMod install, so **I have not manually exercised the Settings language switch**. The reasoning above is from the source alone and is worth a maintainer sanity-check.
