### PR TITLE
fix(installed-apps): prefer Steam client icon and honour the store fallback

### DIFF
--- a/web-panel/bridge/scripts/default/installed-apps-sync/installed-data.js
+++ b/web-panel/bridge/scripts/default/installed-apps-sync/installed-data.js
@@ -22,7 +22,10 @@ import {
 export function resolveInstalledData(state) {
   const storeState = getStoreState(state.storeRef)
 
-  if (isRecord(state.installedAppsService?.installedApps)) {
+  // A populated slice is required, not merely a present one: the service starts with
+  // an empty installedApps object and only fills it in refreshApps. Accepting {} here
+  // would take this branch with nothing to match and skip the store fallback below.
+  if (isNonEmptyRecord(state.installedAppsService?.installedApps)) {
     return {
       rawInstalledApps: state.installedAppsService.installedApps,
       catalog: isRecord(state.installedAppsService.catalog)
@@ -351,6 +354,10 @@ export function getInstalledVersionsForGame(gameId, data) {
   )
 }
 
+function isNonEmptyRecord(value) {
+  return isRecord(value) && Object.keys(value).length > 0
+}
+
 function getStoreState(storeRef) {
   const state =
     typeof storeRef?.state?.getValue === "function"
@@ -561,17 +568,19 @@ function pickImageUrlForTitle(title, game, preferredApp, sidebarClientIconUrl, v
     : [title, game, preferredApp]
 
   return pickImageUrl(
+    // The Wand client icon CDN wins whenever a Steam AppID is resolvable, on any
+    // install platform. It yields null when no AppID is found, so the metadata
+    // candidates below still apply to non-Steam titles.
+    getSteamClientIconUrl(
+      findSteamAppId(...steamRoots),
+      getInstalledAppSteamAppId(preferredApp.platform, preferredApp.sku)
+    ),
     title?.imageUrl,
     title?.iconUrl,
     title?.coverUrl,
     title?.thumbnailUrl,
     title?.logoUrl,
     title?.headerImageUrl,
-    getSteamClientIconUrl(
-      findSteamAppId(...steamRoots),
-      getInstalledAppSteamAppId(preferredApp.platform, preferredApp.sku)
-    ),
-    sidebarClientIconUrl,
     title?.images,
     title?.assets,
     game.imageUrl,
@@ -582,6 +591,9 @@ function pickImageUrlForTitle(title, game, preferredApp, sidebarClientIconUrl, v
     game.headerImageUrl,
     game.images,
     game.assets,
-    preferredApp.imageUrl
+    preferredApp.imageUrl,
+    // Scraped from the rendered sidebar, so it is the last resort once no
+    // metadata source exposed artwork.
+    sidebarClientIconUrl
   )
 }

--- a/web-panel/bridge/src/renderer-scripts.test.ts
+++ b/web-panel/bridge/src/renderer-scripts.test.ts
@@ -5,7 +5,44 @@ import {
   getSteamClientIconUrl,
   normalizeImageUrl,
 } from '../scripts/default/installed-apps-sync/artwork.js';
+import {
+  buildSnapshot,
+  resolveInstalledData,
+} from '../scripts/default/installed-apps-sync/installed-data.js';
 import { resolveQrRenderer } from '../scripts/default/remote-popup-cleanup/qr-renderer.js';
+
+const CLIENT_ICON_URL =
+  'https://api-cdn.wemod.com/steam_community/1245620/client_icon/96.webp';
+
+function makeInstalledAppsState(
+  correlationId: string,
+  app: Record<string, unknown>,
+  title: Record<string, unknown> = {}
+) {
+  return {
+    log: () => undefined,
+    storeRef: null,
+    unavailableTitlesById: {},
+    installedAppsService: {
+      installedApps: { [correlationId]: app },
+      catalog: {
+        games: {
+          '900': {
+            titleId: '500',
+            correlationIds: [correlationId],
+            displayName: 'Subnautica',
+          },
+        },
+        titles: {
+          '500': { name: 'Subnautica', ...title },
+        },
+      },
+      installedVersions: {
+        '900': [{ correlationId }],
+      },
+    },
+  };
+}
 
 describe('installed-apps renderer script models', () => {
   it('normalizes captured artwork shapes without a Wand runtime', () => {
@@ -28,6 +65,56 @@ describe('installed-apps renderer script models', () => {
     expect(findSteamAppId(fixture)).toBe('1245620');
     expect(getSteamClientIconUrl(findSteamAppId(fixture)))
       .toBe('https://api-cdn.wemod.com/steam_community/1245620/client_icon/96.webp');
+  });
+
+  it('prefers the Steam client icon over the title\'s own artwork fields', () => {
+    const snapshot = buildSnapshot(
+      makeInstalledAppsState(
+        'steam:1245620',
+        { platform: 'steam', sku: '1245620', displayName: 'Subnautica' },
+        {
+          imageUrl: 'https://cdn.example/subnautica-cover.webp',
+          coverUrl: 'https://cdn.example/subnautica-alt.webp',
+        }
+      )
+    );
+
+    expect(snapshot?.apps).toHaveLength(1);
+    expect(snapshot?.apps[0].imageUrl).toBe(CLIENT_ICON_URL);
+  });
+
+  it('falls back to title artwork when no Steam AppID is resolvable', () => {
+    const snapshot = buildSnapshot(
+      makeInstalledAppsState(
+        'epic:abc',
+        { platform: 'epic', sku: 'abc', displayName: 'Subnautica' },
+        { imageUrl: 'https://cdn.example/epic-cover.webp' }
+      )
+    );
+
+    expect(snapshot?.apps[0].imageUrl).toBe('https://cdn.example/epic-cover.webp');
+  });
+
+  it('reads installed apps from the store while the service slice is still empty', () => {
+    const storeInstalledApps = {
+      'steam:1245620': { platform: 'steam', sku: '1245620' },
+    };
+    const data = resolveInstalledData({
+      unavailableTitlesById: {},
+      installedAppsService: { installedApps: {} },
+      storeRef: {
+        state: {
+          getValue: () => ({
+            installedApps: storeInstalledApps,
+            catalog: {},
+            installedGameVersions: {},
+          }),
+        },
+      },
+    });
+
+    expect(data?.source).toBe('store');
+    expect(data?.rawInstalledApps).toBe(storeInstalledApps);
   });
 
   it('resolves the tree-shaken Wand QR renderer without a create export', () => {


### PR DESCRIPTION
﻿Fixes #166

Two defects in `installed-data.js`, both affecting the `My Games` snapshot. They share a file, so they share a PR — no other open PR of mine touches it.

### 1. Steam `client_icon` was unreachable

`pickImageUrl` returns the first non-null candidate in argument order, and `getSteamClientIconUrl(...)` sat at argument 7, behind six `title.*` image fields. Any title carrying flat artwork won, so the client icon CDN shape was never selected — the inverse of the rule in `AGENTS.md:20` ("must prefer … whenever the matched title/game/version metadata contains a Steam AppID, regardless of install platform").

Moved it to the front. It returns `null` when no AppID resolves, so non-Steam titles keep falling through to their own metadata with identical results.

The sidebar candidate moved the other way — argument 8 → last. AGENTS.md describes the rendered sidebar DOM as the fallback used *only* when metadata does not expose the icon, but it was overriding every `game.*` field.

### 2. Empty service slice bypassed the store fallback

`isRecord({})` is `true`, so an `installedAppsService.installedApps` of `{}` (its state before `refreshApps` fills it) took the service branch with nothing to match and skipped the store branch below. Now that branch requires a non-empty record. `catalog` and `installedGameVersions` are untouched — they already chain their own store fallbacks.

### Tests

Three tests added, all driven through the **public** `buildSnapshot` / `resolveInstalledData` contracts. Per `web-panel/CLAUDE.md` ("test product behavior and public contracts", "keep implementation-only helpers private") I did **not** export `pickImageUrlForTitle` to test it directly — the fixtures go through the real snapshot path instead.

Both bug-specific tests were confirmed to fail against the unfixed source before the fix was applied:

```
× prefers the Steam client icon over the title's own artwork fields
  Expected: "https://api-cdn.wemod.com/steam_community/1245620/client_icon/96.webp"
  Received: "https://cdn.example/subnautica-cover.webp"

× reads installed apps from the store while the service slice is still empty
  Expected: "store"
  Received: "service"
```

The third test pins the non-Steam path (`epic:` correlation → title artwork still wins) so the reorder cannot over-correct.

### Verification

Run locally on Node 22.23.1 / pnpm 10.17.0, the versions `.github/workflows/build.yml` pins:

- `pnpm test` — **37 passed** (12 files), up from 34 on `master`
- `pnpm lint` — clean at `--max-warnings=0`
- `pnpm typecheck` — clean (both `typecheck:web` and `typecheck:bridge`)

### Note on visible behaviour

This intentionally changes what users see: Steam titles that previously showed a wide catalog cover will now show the 96px `client_icon`. That is what AGENTS.md mandates, but it is a visual change rather than a silent correctness fix, so flagging it explicitly in case the documented rule no longer reflects your intent — happy to drop that half and keep only the store-fallback fix if so.

I do not have a licensed WeMod install, so I have **not** exercised this against a live Wand renderer; the evidence above is the unit suite plus the documented invariant.
