### PR TITLE
fix(remote-popup): stop the refresh loop from re-triggering itself

### DIFF
--- a/web-panel/bridge/scripts/default/remote-popup-cleanup.js
+++ b/web-panel/bridge/scripts/default/remote-popup-cleanup.js
@@ -100,9 +100,19 @@ import { resolveQrRenderer as findWandQrRenderer } from "./remote-popup-cleanup/
       return
     }
 
+    const linkText = remoteUrl.replace(/\/$/, "")
     for (const anchor of document.querySelectorAll("remote-tooltip a[href]")) {
-      anchor.setAttribute("href", remoteUrl)
-      anchor.textContent = remoteUrl.replace(/\/$/, "")
+      if (anchor.getAttribute("href") !== remoteUrl) {
+        anchor.setAttribute("href", remoteUrl)
+      }
+
+      // Assigning textContent always replaces the child text node, which emits a
+      // childList record even when the string is unchanged. The observer below
+      // watches childList on documentElement, so an unguarded write here would
+      // schedule the next refresh and never settle.
+      if (anchor.textContent !== linkText) {
+        anchor.textContent = linkText
+      }
     }
   }
 

--- a/web-panel/bridge/src/remote-popup-cleanup.test.ts
+++ b/web-panel/bridge/src/remote-popup-cleanup.test.ts
@@ -1,0 +1,56 @@
+// bridge/tsconfig.json targets the Node-side bridge and so omits the DOM lib.
+// This suite drives a renderer script under vitest's jsdom environment, so it
+// pulls the DOM types in locally rather than widening the project config.
+/// <reference lib="dom" />
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const REMOTE_URL = 'http://192.168.1.5:8080/';
+
+/** Lets the script's setTimeout(0) refresh loop run for a few turns. */
+async function settle(turns = 8) {
+  for (let index = 0; index < turns; index += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe('remote popup cleanup', () => {
+  afterAll(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('leaves the remote link alone once it matches, so the refresh loop settles', async () => {
+    document.body.innerHTML =
+      '<remote-tooltip><a href="http://stale.invalid/">stale</a></remote-tooltip>';
+    (globalThis as Record<string, unknown>).__wandRemoteBridgeUrl = REMOTE_URL;
+
+    // Installs on import: runs one refresh, then observes documentElement.
+    await import('../scripts/default/remote-popup-cleanup.js');
+    await settle();
+
+    const anchor = document.querySelector('remote-tooltip a[href]');
+    expect(anchor?.getAttribute('href')).toBe(REMOTE_URL);
+    expect(anchor?.textContent).toBe('http://192.168.1.5:8080');
+
+    // The script's own refresh happens before it starts observing, so the loop
+    // needs one external mutation to kick it off. After this the link already
+    // holds the right value, so a correct updateLinks writes nothing further.
+    document.body.appendChild(document.createElement('div'));
+    await settle(2);
+
+    // An unguarded `anchor.textContent = ...` replaces the child text node on
+    // every pass. That is a childList record on documentElement, which
+    // re-triggers the script's observer, which schedules another refresh --
+    // a loop that never quiesces while a remote-tooltip anchor is present.
+    let mutationCount = 0;
+    const probe = new MutationObserver((records) => {
+      mutationCount += records.length;
+    });
+    probe.observe(document.documentElement, { childList: true, subtree: true });
+
+    await settle();
+    probe.disconnect();
+
+    expect(mutationCount).toBe(0);
+  });
+});


### PR DESCRIPTION
﻿Fixes #168

### Problem

`updateLinks` assigned `anchor.textContent` unconditionally. Assigning `textContent` always removes the existing child text node and inserts a new one, so it emits a `childList` record even when the string is unchanged.

The script observes `childList`/`subtree` on `document.documentElement`, so that write fed straight back into its own observer:

```
refresh → updateLinks writes textContent → childList record →
scheduleRefresh → setTimeout(0) → refresh → …
```

`refreshScheduled` is reset before `refresh()` runs, so each pass schedules the next. Once any DOM change kicked the loop off, it sustained itself for as long as a `remote-tooltip` anchor was present.

### Change

Compare before writing — the same idea `updateQrCodes` already uses at `:116` (`canvas.dataset.wandRemoteUrl === remoteUrl`). The `href` write is guarded too for symmetry, though it was never a contributor since `attributes` is not observed.

No behavioural change to what the link ends up showing; only the redundant rewrites go away.

### Test

New `bridge/src/remote-popup-cleanup.test.ts`. The script's own initial `refresh()` runs *before* it starts observing, so the loop needs one external mutation to start — the test supplies exactly one `appendChild`, then counts mutations over 8 macrotasks.

Verified to fail against the unfixed script:

```
AssertionError: expected 8 to be 0
- 0
+ 8
```

One mutation per macrotask — the loop is self-sustaining. With the fix, 0.

`bridge/tsconfig.json` deliberately omits the DOM lib (it targets the Node-side bridge, `lib: ["ES2022"]`, `types: ["node"]`). Rather than widen that config for one test, the file pulls DOM types in locally with `/// <reference lib="dom" />`.

### Verification

Node 22.23.1 / pnpm 10.17.0, matching the versions `.github/workflows/build.yml` pins:

- `pnpm test` — **35 passed** (13 files), up from 34 on `master`
- `pnpm lint` — clean at `--max-warnings=0`
- `pnpm typecheck` — clean (`typecheck:web` and `typecheck:bridge`)

I do not have a licensed WeMod install, so this has **not** been exercised against a live Wand renderer — the evidence is the jsdom reproduction above.
