### PR TITLE
fix(asar): emit integrity blocks on real block boundaries

### DIFF
--- a/AsarSharp/Integrity/IntegrityHelper.cs
+++ b/AsarSharp/Integrity/IntegrityHelper.cs
@@ -46,8 +46,10 @@ namespace AsarSharp.Integrity
 
         public static FileIntegrity GetFileIntegrity(string path, byte[] reusableBuffer = null)
         {
-            bool ownBuffer = reusableBuffer == null;
-            if (ownBuffer) reusableBuffer = new byte[BLOCK_SIZE];
+            // A block must be exactly BLOCK_SIZE for Electron to validate it, so a buffer
+            // that cannot hold a whole block is replaced rather than used as-is.
+            if (reusableBuffer == null || reusableBuffer.Length < BLOCK_SIZE)
+                reusableBuffer = new byte[BLOCK_SIZE];
 
             using (var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read,
                        65536, FileOptions.SequentialScan))
@@ -58,13 +60,27 @@ namespace AsarSharp.Integrity
                     ? (int)((fileStream.Length + BLOCK_SIZE - 1) / BLOCK_SIZE)
                     : 0;
                 var blockHashes = new List<string>(estimatedBlockCount);
+                int blockFill = 0;
                 int bytesRead;
 
-                while ((bytesRead = fileStream.Read(reusableBuffer, 0, reusableBuffer.Length)) > 0)
+                // Stream.Read may return fewer bytes than requested at any point, so reads
+                // accumulate into the block buffer and a hash is only emitted once a full
+                // block is present. Hashing each read directly would turn a short read into
+                // an undersized block and desynchronise every boundary after it.
+                while ((bytesRead = fileStream.Read(reusableBuffer, blockFill, BLOCK_SIZE - blockFill)) > 0)
                 {
-                    blockHashes.Add(ToLowerHex(blockHash.ComputeHash(reusableBuffer, 0, bytesRead)));
-                    fileHash.AppendData(reusableBuffer, 0, bytesRead);
+                    fileHash.AppendData(reusableBuffer, blockFill, bytesRead);
+                    blockFill += bytesRead;
+
+                    if (blockFill == BLOCK_SIZE)
+                    {
+                        blockHashes.Add(ToLowerHex(blockHash.ComputeHash(reusableBuffer, 0, BLOCK_SIZE)));
+                        blockFill = 0;
+                    }
                 }
+
+                if (blockFill > 0)
+                    blockHashes.Add(ToLowerHex(blockHash.ComputeHash(reusableBuffer, 0, blockFill)));
 
                 return new FileIntegrity
                 {


### PR DESCRIPTION
﻿Fixes #170

### Problem

`GetFileIntegrity` hashed each `Stream.Read` result as if it were a complete block. `Stream.Read` may return fewer bytes than requested at any point, not only at EOF, so a short read produced an undersized `integrity.blocks[]` entry and shifted every boundary after it — metadata that fails Electron's `validateAsarIntegrity`, which requires every block except the last to be exactly `blockSize`.

Reachable through `FileSystem.InsertFile`, which calls it as the `precomputedIntegrity ?? …` fallback at `:175` and `:184`. The whole-file `hash` was never affected.

### Change

Accumulate reads into the block buffer and emit a hash only when a full block is present, flushing the remainder after the loop. Reads target the tail of the buffer (`Read(buf, blockFill, BLOCK_SIZE - blockFill)`), so there is no copying and no extra allocation.

Also replaces a caller-supplied buffer shorter than `BLOCK_SIZE`, since such a buffer cannot produce a valid block either way. No current caller passes one.

### A note on reuse

`StreamingHasher` in the same file already implements this rule correctly, and delegating to it was the obvious way to remove the duplication. I did not, for a concrete reason: `StreamingHasher.Append` copies the caller's data into its **own** block buffer, so passing one array as both the read target and the shared block buffer would alias — `Buffer.BlockCopy(data, src, _blockBuf, _blockFill, copy)` would overwrite unread source bytes whenever `_blockFill > 0`. The alternatives were an extra 4 MiB allocation per file or a per-byte copy. Fixing the loop in place keeps the copy-free read path; happy to switch if you'd rather have the single implementation.

### Verification

No local Visual Studio/MSBuild environment, so **this is not compile-verified locally**. Compile evidence comes from dispatching this repo's own `.github/workflows/build.yml` (full `build.ps1` → MSBuild, `windows-latest`) on my fork; run linked in a comment below.

The algorithm itself I verified by simulating the read/boundary arithmetic against Electron's rule (block size scaled down, arithmetic identical):

```
scenario                 expected    master    fixed   verdict
short read mid-file             5         6        5   master diverges
every read short (1 byte)       5        40        5   master diverges
ragged reads                    5         6        5   master diverges
all reads full                 32        32       32   both correct
exact multiple of block         4         4        4   both correct
single sub-block file           1         1        1   both correct
empty file                      0         0        0   both correct
```

`master` and the fix agree whenever every read is full — the normal case, and why this is latent — and diverge on every short-read scenario. Whole-file hash preserved throughout.

The repo has no C# test project, so there is no unit test to add here. I also have no licensed WeMod install, so CONTRIBUTING.md's "manually tested against the current WeMod version" is **not** satisfied — worth a maintainer check against a real packing run.
